### PR TITLE
Ensure image is RGB

### DIFF
--- a/osc-picasso.py
+++ b/osc-picasso.py
@@ -22,6 +22,7 @@ args = parser.parse_args()
 # Load image
 from PIL import Image
 img = Image.open(args.img)
+img = img.convert('RGB') // Convert to RGB to ensure getPixel properly outputs 3 values
 
 # Get aspect ratio
 ratio = img.size[0] / img.size[1]


### PR DESCRIPTION
This fixes a potential confusion where some PIL will report that getPixel isn't subscribeable.